### PR TITLE
Fixing edge case where key < oldest_mutable_timestamp but next(key) == oldest_mutable_timestamp

### DIFF
--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -230,7 +230,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                                oldest_mutable_timestamp):
         # NOTE(jd) We write the full split only if the driver works that way
         # (self.WRITE_FULL) or if the oldest_mutable_timestamp is out of range.
-        write_full = self.WRITE_FULL or next(key) < oldest_mutable_timestamp
+        write_full = self.WRITE_FULL or next(key) <= oldest_mutable_timestamp
         key_as_str = str(key)
         if write_full:
             try:


### PR DESCRIPTION
Under the condition of key < oldest_mutable_timestamp the function _store_timeserie_split is called from line 316 using split == None.

The problem is that if self.WRITE_FULL and next(key) == oldest_mutable_timestamp then write_full == False resulting in calling split.serialize when split is None.

This produce metricd to crash resulting an increase of the backlog of measurement to process. I needed to stop all my ceilometer collector and add the following pull request to fix the issue.

The archive policy I am using is:

| xxxx  |           0 | - points: 720, granularity: 0:05:00, timespan: 2 days, 12:00:00         | max, min, mean                                 |
|        |             | - points: 720, granularity: 0:30:00, timespan: 15 days, 0:00:00         |                                                |
|        |             | - points: 744, granularity: 2:00:00, timespan: 62 days, 0:00:00         |                                                |
|        |             | - points: 762, granularity: 1 day, 0:00:00, timespan: 762 days, 0:00:00 |                                                |

This might not be the right solution however, I wanted to volunteer it because it cause me some pain when I hit this edge case.